### PR TITLE
Change declaration from assign to weak

### DIFF
--- a/MGSwipeTableCell/MGSwipeTableCell.h
+++ b/MGSwipeTableCell/MGSwipeTableCell.h
@@ -120,7 +120,7 @@ typedef NS_ENUM(NSInteger, MGSwipeState) {
 @interface MGSwipeTableCell : UITableViewCell
 
 /** optional delegate (not retained) */
-@property (nonatomic, assign) id<MGSwipeTableCellDelegate> delegate;
+@property (nonatomic, weak) id<MGSwipeTableCellDelegate> delegate;
 
 /** optional to use contentView alternative. Use this property instead of contentView to support animated views while swipping */
 @property (nonatomic, strong, readonly) UIView * swipeContentView;


### PR DESCRIPTION
This will nil-out the delegate when deallocated.
This prevents a crash that happens if the delegate is deallocated before the button-hiding animation completes

This was issue:
Animation Timers after delegate deallocated #33
