### PR TITLE
Fix expanding from the right with a single button

### DIFF
--- a/MGSwipeTableCell/MGSwipeTableCell.m
+++ b/MGSwipeTableCell/MGSwipeTableCell.m
@@ -159,7 +159,7 @@
         
         if (!_fromLeft) {
             CGRect buttonFrame = _expandedButton.frame;
-            buttonFrame.origin.x = frame.origin.x - buttonFrame.size.width;
+            buttonFrame.origin.x = _expansionBackground.frame.origin.x - buttonFrame.size.width;
             _expandedButton.frame = buttonFrame;
         }
         


### PR DESCRIPTION
Related to Issue #37 

When expanding from the right with a single button, the _expansionBackground and _expandedButton frames are not animated because their frames have the same X position outside the animate block as what gets set in the block.  

Please let me know if you see a problem with the approach I took.  I would be happy to change it if you have a different approach.
