### PR TITLE
Fixed the crash when the button target is set to a deallocated cell

### DIFF
--- a/MGSwipeTableCell/MGSwipeTableCell.m
+++ b/MGSwipeTableCell/MGSwipeTableCell.m
@@ -71,6 +71,7 @@
         _buttons = _fromLeft ? buttonsArray: [[buttonsArray reverseObjectEnumerator] allObjects];
         for (UIView * button in _buttons) {
             if ([button isKindOfClass:[UIButton class]]) {
+                [(UIButton *)button removeTarget:nil action:@selector(buttonClicked:) forControlEvents:UIControlEventTouchUpInside];
                 [(UIButton *)button addTarget:self action:@selector(buttonClicked:) forControlEvents:UIControlEventTouchUpInside];
             }
             button.frame = CGRectMake(0, 0, maxSize.width, maxSize.height);


### PR DESCRIPTION
This PR fixes the crash when the button target is set (and called) to a previously deallocated cell. This could happen because the buttons are reused and the old target was not removed before the reuse.

Typical case was the table view where the cells could be deleted. Tapping on a swipe button would remove the cell, but the target would remain set to this instance. On the next try, the app would crash this way:
`[MGSwipeButtonsView performSelector:withObject:withObject:]: message sent to deallocated instance 0x7fa605091390`
