### PR TITLE
added utility method to expand swipe animation

### DIFF
--- a/MGSwipeTableCell/MGSwipeTableCell.h
+++ b/MGSwipeTableCell/MGSwipeTableCell.h
@@ -152,6 +152,7 @@ typedef NS_ENUM(NSInteger, MGSwipeState) {
 -(void) hideSwipeAnimated: (BOOL) animated;
 -(void) showSwipe: (MGSwipeDirection) direction animated: (BOOL) animated;
 -(void) setSwipeOffset:(CGFloat)offset animated: (BOOL) animated completion:(void(^)()) completion;
+-(void) expandSwipe: (MGSwipeDirection) direction animated: (BOOL) animated;
 
 /** Refresh method to be used when you want to update the cell contents while the user is swipping */
 -(void) refreshContentView;

--- a/MGSwipeTableCell/MGSwipeTableCell.m
+++ b/MGSwipeTableCell/MGSwipeTableCell.m
@@ -813,6 +813,29 @@ typedef struct MGSwipeAnimationData {
     }
 }
 
+-(void) expandSwipe: (MGSwipeDirection) direction animated: (BOOL) animated
+{
+    CGFloat s = direction == MGSwipeDirectionLeftToRight ? 1.0 : -1.0;
+    MGSwipeExpansionSettings* expSetting = direction == MGSwipeDirectionLeftToRight ? _leftExpansion : _rightExpansion;
+    
+    // only perform animation if there's no pending expansion animation and requested direction has fillOnTrigger enabled
+    if(!_activeExpansion && expSetting.fillOnTrigger) {
+        [self createSwipeViewIfNeeded];
+        _allowSwipeLeftToRight = _leftButtons.count > 0;
+        _allowSwipeRightToLeft = _rightButtons.count > 0;
+        UIView * buttonsView = direction == MGSwipeDirectionLeftToRight ? _leftView : _rightView;
+        
+        if (buttonsView) {
+            __weak typeof(_activeExpansion) w_expantionView = direction == MGSwipeDirectionLeftToRight ? _leftView : _rightView;
+            __weak typeof(self) weakself = self;
+            [self setSwipeOffset:buttonsView.bounds.size.width * s * expSetting.threshold * 2 animated:animated completion:^{
+                [w_expantionView endExpansioAnimated:YES];
+                [weakself setSwipeOffset:0 animated:NO completion:nil];
+            }];
+        }
+    }
+}
+
 -(void) animationTick: (CADisplayLink *) timer
 {
     if (!_animationData.start) {


### PR DESCRIPTION
calling this from button callback function will animate its expansion if configured for it.

example use:
                                       MGSwipeButton * trashButton = [MGSwipeButton buttonWithTitle:@""
                                                                icon:[UIImage imageNamed:@"trash"]
                                                     backgroundColor:[UIColor colorWithRed:1.0f green:59/255.0f blue:50/255.0f alpha:1.0f]
                                                             padding:padding
                                                            callback:
                                       ^BOOL(MGSwipeTableCell *sender) {
                                           NSLog(@"Swipe delete");
                                           NSIndexPath * indexPath = [me.tableView indexPathForCell:sender];
                                           indexPath=indexPath;
                                           [me deleteMail:indexPath];
                                           [cell expandSwipe:MGSwipeDirectionRightToLeft animated:YES];
                                           return NO;
                                       }];