### PR TITLE
Adding a field to MGSwipeButton to allow you to specify a button width instead of sizingToFit

### DIFF
--- a/MGSwipeTableCell/MGSwipeButton.h
+++ b/MGSwipeTableCell/MGSwipeButton.h
@@ -22,6 +22,9 @@
 typedef BOOL(^MGSwipeButtonCallback)(MGSwipeTableCell * sender);
 @property (nonatomic, strong) MGSwipeButtonCallback callback;
 
+/** A width for the expanded buttons. Defaults to 0, which means sizeToFit will be called. */
+@property (nonatomic, assign) CGFloat buttonWidth;
+
 /** 
  * Convenience static constructors
  */

--- a/MGSwipeTableCell/MGSwipeButton.m
+++ b/MGSwipeTableCell/MGSwipeButton.m
@@ -72,4 +72,19 @@
     [self sizeToFit];
 }
 
+- (void)setButtonWidth:(CGFloat)buttonWidth
+{
+    _buttonWidth = buttonWidth;
+    if (_buttonWidth > 0)
+    {
+        CGRect frame = self.frame;
+        frame.size.width = _buttonWidth;
+        self.frame = frame;
+    }
+    else
+    {
+        [self sizeToFit];
+    }
+}
+
 @end


### PR DESCRIPTION
This allows people to have more control, for example being able replicate the way Mail.app displays content.