### PR TITLE
Update MGSwipeTableCell.podspec

### DIFF
--- a/MGSwipeTableCell.podspec
+++ b/MGSwipeTableCell.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/MortimerGoro/MGSwipeTableCell'
   s.summary  = 'An easy to use UITableViewCell subclass that allows to display swippable buttons with a variety of transitions'
   s.license  = 'MIT'
-  s.source   = { :git => 'https://github.com/MortimerGoro/MGSwipeTableCell.git', :tag => '1.3.6' }
+  s.source   = { :git => 'https://github.com/MortimerGoro/MGSwipeTableCell.git', :tag => s.version.to_s }
   s.source_files = 'MGSwipeTableCell'
   s.platform = :ios
   s.ios.deployment_target = '5.0'


### PR DESCRIPTION
Changed the `:tag` in `s.source` to copy the version number from `s.version`.

This way you only have to change the version in one place, which means there's less chance to forget or make a mistake.