### PR TITLE
Center image over text in MGSwipeButton

### DIFF
--- a/MGSwipeTableCell/MGSwipeButton.h
+++ b/MGSwipeTableCell/MGSwipeButton.h
@@ -38,5 +38,6 @@ typedef BOOL(^MGSwipeButtonCallback)(MGSwipeTableCell * sender);
 +(instancetype) buttonWithTitle:(NSString *) title icon:(UIImage*) icon backgroundColor:(UIColor *) color padding:(NSInteger) padding callback:(MGSwipeButtonCallback) callback;
 
 -(void) setPadding:(CGFloat) padding;
+-(void) centerIconOverText;
 
 @end

--- a/MGSwipeTableCell/MGSwipeButton.m
+++ b/MGSwipeTableCell/MGSwipeButton.m
@@ -66,6 +66,20 @@
     return NO;
 }
 
+-(void) centerIconOverText {
+	const CGFloat spacing = 3.0;
+	CGSize size = self.imageView.image.size;
+	self.titleEdgeInsets = UIEdgeInsetsMake(0.0,
+											-size.width,
+											-(size.height + spacing),
+											0.0);
+	size = [self.titleLabel.text sizeWithAttributes:@{ NSFontAttributeName: self.titleLabel.font }];
+	self.imageEdgeInsets = UIEdgeInsetsMake(-(size.height + spacing),
+											0.0,
+											0.0,
+											-size.width);
+}
+
 -(void) setPadding:(CGFloat) padding
 {
     self.contentEdgeInsets = UIEdgeInsetsMake(0, padding, 0, padding);


### PR DESCRIPTION
Would you be willing to add functionality which moves the button image over the button text?
Here is a PR which creates buttons like this picture:
![screen shot 2015-03-12 at 10 05 52 pm](https://cloud.githubusercontent.com/assets/4912283/6633416/693aaf5c-c905-11e4-92b0-b9dceaff53cd.png)

There is no side effect if this new method is not called, so it should be fairly low risk.
I have tested this in the iPhone6-iOS8 & the iPhone5-iOS7 simulator, and it behaves nicely.