### PR TITLE
Make MGSwipeTableCell more extensible

### DIFF
--- a/MGSwipeTableCell/MGSwipeTableCell.h
+++ b/MGSwipeTableCell/MGSwipeTableCell.h
@@ -166,6 +166,9 @@ typedef NS_ENUM(NSInteger, MGSwipeState) {
  * @param usingDelegate if YES new buttons will be fetched using the MGSwipeTableCellDelegate. Otherwise new buttons will be fetched from leftButtons/rightButtons properties.
  */
 -(void) refreshButtons: (BOOL) usingDelegate;
-
+/** This is an override point so that subclasses can to any last-minute tweaking to the swipe buttons view
+ * @param swipeButtonView will be of the private type MGSwipeButtonsView.
+ */
+-(void) customizeSwipeButtonsView: (UIView *) swipeButtonView;
 @end
 

--- a/MGSwipeTableCell/MGSwipeTableCell.m
+++ b/MGSwipeTableCell/MGSwipeTableCell.m
@@ -534,6 +534,7 @@ static NSMutableSet * singleSwipePerTable;
         _leftView.autoresizingMask = UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleHeight;
         _leftView.cell = self;
         _leftView.frame = CGRectMake(-_leftView.bounds.size.width, 0, _leftView.bounds.size.width, _swipeOverlay.bounds.size.height);
+        [self customizeSwipeButtonsView:_leftView];
         [_swipeOverlay addSubview:_leftView];
     }
     if (!_rightView && _rightButtons.count > 0) {
@@ -541,6 +542,7 @@ static NSMutableSet * singleSwipePerTable;
         _rightView.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleHeight;
         _rightView.cell = self;
         _rightView.frame = CGRectMake(_swipeOverlay.bounds.size.width, 0, _rightView.bounds.size.width, _swipeOverlay.bounds.size.height);
+        [self customizeSwipeButtonsView:_rightView];
         [_swipeOverlay addSubview:_rightView];
     }
 }
@@ -1024,6 +1026,10 @@ static NSMutableSet * singleSwipePerTable;
 -(BOOL) isSwipeGestureActive
 {
     return _panRecognizer.state == UIGestureRecognizerStateBegan || _panRecognizer.state == UIGestureRecognizerStateChanged;
+}
+
+-(void) customizeSwipeButtonsView:(UIView *)swipeButtonView
+{
 }
 
 @end


### PR DESCRIPTION
Create an override point for subclasses to customize the appearance of the MGSwipeButtonsView.
This can be used to set a color/background on the MGSwipeButtonsView (which will show through if some/all of the buttons have a clear background)

I'm using this in my project to set a background image under all buttons, and then I set the MGSwipeButton color to [UIColor clearColor]. If you'd be interested promoting a background UIImage to a 1st class citizen, let me know and I can probably offer a PR for that as well (though my code is using SDWebImage, so I'd have to refactor.)

This is fairly low risk because the default implementation does nothing and presumably no existing clients are overriding this new selector.

It looks something like this:
![screen shot 2015-03-13 at 5 57 31 pm](https://cloud.githubusercontent.com/assets/4912283/6649590/9a5ce492-c9aa-11e4-8083-4bb5b6e2a258.png)
