### PR TITLE
Fixed crash in MGSwipeTableCell when using multiple sections with different types of cell

### DIFF
--- a/MGSwipeTableCell/MGSwipeTableCell.m
+++ b/MGSwipeTableCell/MGSwipeTableCell.m
@@ -980,7 +980,7 @@ typedef struct MGSwipeAnimationData {
         if (!_allowsMultipleSwipe) {
             NSArray * cells = [self parentTable].visibleCells;
             for (MGSwipeTableCell * cell in cells) {
-                if (cell != self) {
+                if ([cell isKindOfClass:[MGSwipeTableCell class]] && cell != self) {
                     [cell cancelPanGesture];
                 }
             }


### PR DESCRIPTION
MGSwipeTableCell was crashing in case you had more than 1 section in your table view with different kinds of cells.
In case you have any cell other than MGSwipeCell in any of the sections, where the cell is visible, the application will crash with unrecognized selector exception.
The above fix will only call cancelPanGesture on cells which are of type MGSwipeTableCell.