### PR TITLE
Add completion handlers to convenience show/hide methods

### DIFF
--- a/MGSwipeTableCell/MGSwipeTableCell.h
+++ b/MGSwipeTableCell/MGSwipeTableCell.h
@@ -170,7 +170,9 @@ typedef NS_ENUM(NSInteger, MGSwipeExpansionLayout) {
 
 /** Utility methods to show or hide swipe buttons programmatically */
 -(void) hideSwipeAnimated: (BOOL) animated;
+-(void) hideSwipeAnimated: (BOOL) animated completion:(void(^)()) completion;
 -(void) showSwipe: (MGSwipeDirection) direction animated: (BOOL) animated;
+-(void) showSwipe: (MGSwipeDirection) direction animated: (BOOL) animated completion:(void(^)()) completion;
 -(void) setSwipeOffset:(CGFloat)offset animated: (BOOL) animated completion:(void(^)()) completion;
 -(void) expandSwipe: (MGSwipeDirection) direction animated: (BOOL) animated;
 

--- a/MGSwipeTableCell/MGSwipeTableCell.m
+++ b/MGSwipeTableCell/MGSwipeTableCell.m
@@ -877,7 +877,7 @@ typedef struct MGSwipeAnimationData {
 
 -(void) showSwipe: (MGSwipeDirection) direction animated: (BOOL) animated
 {
-    [self showSwipe:direction animated:animated completion:nil]
+    [self showSwipe:direction animated:animated completion:nil];
 }
 
 -(void) showSwipe: (MGSwipeDirection) direction animated: (BOOL) animated completion:(void(^)()) completion

--- a/MGSwipeTableCell/MGSwipeTableCell.m
+++ b/MGSwipeTableCell/MGSwipeTableCell.m
@@ -865,12 +865,22 @@ typedef struct MGSwipeAnimationData {
     self.swipeOffset = offset;
 }
 
+-(void) hideSwipeAnimated: (BOOL) animated completion:(void(^)()) completion
+{
+    [self setSwipeOffset:0 animated:animated completion:completion];
+}
+
 -(void) hideSwipeAnimated: (BOOL) animated
 {
     [self setSwipeOffset:0 animated:animated completion:nil];
 }
 
 -(void) showSwipe: (MGSwipeDirection) direction animated: (BOOL) animated
+{
+    [self showSwipe:direction animated:animated completion:nil]
+}
+
+-(void) showSwipe: (MGSwipeDirection) direction animated: (BOOL) animated completion:(void(^)()) completion
 {
     [self createSwipeViewIfNeeded];
     _allowSwipeLeftToRight = _leftButtons.count > 0;
@@ -879,7 +889,7 @@ typedef struct MGSwipeAnimationData {
     
     if (buttonsView) {
         CGFloat s = direction == MGSwipeDirectionLeftToRight ? 1.0 : -1.0;
-        [self setSwipeOffset:buttonsView.bounds.size.width * s animated:animated completion:nil];
+        [self setSwipeOffset:buttonsView.bounds.size.width * s animated:animated completion:completion];
     }
 }
 


### PR DESCRIPTION
Added two new convenience methods:
-(void) hideSwipeAnimated: (BOOL) animated completion:(void(^)()) completion;
and
-(void) showSwipe: (MGSwipeDirection) direction animated: (BOOL) animated completion:(void(^)()) completion;


The first allowed me to easily tap a swipe button, then programmatically hide the swipe buttons, and after they were hidden, refresh the buttons.

The second I thought would be nice and symmetric.