### PR TITLE
Add Property to Cell to control selection

### DIFF
--- a/MGSwipeTableCell/MGSwipeTableCell.h
+++ b/MGSwipeTableCell/MGSwipeTableCell.h
@@ -162,6 +162,8 @@ typedef NS_ENUM(NSInteger, MGSwipeExpansionLayout) {
 @property (nonatomic) BOOL allowsButtonsWithDifferentWidth;
 //default is YES. Controls wheter swipe gesture is allowed when the touch starts into the swiped buttons
 @property (nonatomic) BOOL allowsSwipeWhenTappingButtons;
+// default is NO.  Controls whether the cell selection/highlight status is preserved when expansion occurs
+@property (nonatomic) BOOL preservesSelectionStatus;
 
 /** Optional background color for swipe overlay. If not set, its inferred automatically from the cell contentView */
 @property (nonatomic, strong) UIColor * swipeBackgroundColor;

--- a/MGSwipeTableCell/MGSwipeTableCell.m
+++ b/MGSwipeTableCell/MGSwipeTableCell.m
@@ -484,6 +484,7 @@ typedef struct MGSwipeAnimationData {
     _swipeState = MGSwipeStateNone;
     _triggerStateChanges = YES;
     _allowsSwipeWhenTappingButtons = YES;
+    _preservesSelectionStatus = NO;
 }
 
 -(void) cleanViews
@@ -578,7 +579,8 @@ typedef struct MGSwipeAnimationData {
     }
     _overlayEnabled = YES;
     
-    self.selected = NO;
+    if (!_preservesSelectionStatus)
+        self.selected = NO;
     if (_swipeContentView)
         [_swipeContentView removeFromSuperview];
     _swipeView.image = [self imageFromView:self];
@@ -982,7 +984,8 @@ typedef struct MGSwipeAnimationData {
     CGPoint current = [gesture translationInView:self];
     
     if (gesture.state == UIGestureRecognizerStateBegan) {
-        self.highlighted = NO;
+        if (!_preservesSelectionStatus)
+            self.highlighted = NO;
         [self createSwipeViewIfNeeded];
         _panStartPoint = current;
         _panStartOffset = _swipeOffset;


### PR DESCRIPTION
Adding a property preserve selection/highlight of table view cell when the swipe occurs.

Defaults to NO, so old behavior should be preserved.