### PR TITLE
adds custom delegate methods to inform the delegate upon overlay rela…

### DIFF
--- a/MGSwipeTableCell/MGSwipeTableCell.h
+++ b/MGSwipeTableCell/MGSwipeTableCell.h
@@ -92,6 +92,16 @@ typedef NS_ENUM(NSInteger, MGSwipeExpansionLayout) {
 
 @optional
 /**
+ * Called when overlay will be created
+ **/
+-(void) swipeTableCellWillCreateOverlay:(MGSwipeTableCell*)cell;
+
+/**
+ * Called when overlay will be hidden
+ **/
+-(void) swipeTableCellWillHideOverlay:(MGSwipeTableCell*)cell;
+
+/**
  * Delegate method to enable/disable swipe gestures
  * @return YES if swipe is allowed
  **/

--- a/MGSwipeTableCell/MGSwipeTableCell.m
+++ b/MGSwipeTableCell/MGSwipeTableCell.m
@@ -581,6 +581,9 @@ typedef struct MGSwipeAnimationData {
     self.selected = NO;
     if (_swipeContentView)
         [_swipeContentView removeFromSuperview];
+    if ([self.delegate respondsToSelector:@selector(swipeTableCellWillCreateOverlay:)]) {
+        [self.delegate swipeTableCellWillCreateOverlay:self];
+    }
     _swipeView.image = [self imageFromView:self];
     _swipeOverlay.hidden = NO;
     if (_swipeContentView)
@@ -610,6 +613,9 @@ typedef struct MGSwipeAnimationData {
         return;
     }
     _overlayEnabled = NO;
+    if ([self.delegate respondsToSelector:@selector(swipeTableCellWillHideOverlay:)]) {
+        [self.delegate swipeTableCellWillHideOverlay:self];
+    }
     _swipeOverlay.hidden = YES;
     _swipeView.image = nil;
     if (_swipeContentView) {


### PR DESCRIPTION
The changes add two optional delegate methods to inform the delegate upon overlay related events.
The reason for the changes is, I want to hide a subview after the cell is swiped open. But since the cell is displaying an overlay copy of itself, setHidden no longer works. I have to hide the subview right before the overlay is created. 