### PR TITLE
Fix UITableCellSelectionStyle on end swipe

### DIFF
--- a/MGSwipeTableCell/MGSwipeTableCell.m
+++ b/MGSwipeTableCell/MGSwipeTableCell.m
@@ -752,6 +752,7 @@ static inline CGFloat mgEaseInOutBounce(CGFloat t, CGFloat b, CGFloat c) {
     self.selectionStyle = _previusSelectionStyle;
     NSArray * selectedRows = self.parentTable.indexPathsForSelectedRows;
     if ([selectedRows containsObject:[self.parentTable indexPathForCell:self]]) {
+        self.selected = NO;
         self.selected = YES;
     }
     [self setAccesoryViewsHidden:NO];


### PR DESCRIPTION
Firstly, great library, thanks for sharing! :)

I encountered an issue when swiping ended on a selected table cell. When the cell's selectionStyle was set back to _previousSelectionStyle, the selection style wasn't drawn on the cell. I'm not convinced my solution is the right one, but it seems to work. It seems that setting the selected property to YES on its own isn't enough to force the cell to redraw the chosen selectionStyle.