### PR TITLE
centerIconOverText now takes a spacing argument.

### DIFF
--- a/MGSwipeTableCell/MGSwipeButton.h
+++ b/MGSwipeTableCell/MGSwipeButton.h
@@ -43,6 +43,6 @@ typedef BOOL(^MGSwipeButtonCallback)(MGSwipeTableCell * sender);
 
 -(void) setPadding:(CGFloat) padding;
 -(void) setEdgeInsets:(UIEdgeInsets)insets;
--(void) centerIconOverText;
+-(void) centerIconOverTextWithSpacing: (CGFloat) spacing;
 
 @end

--- a/MGSwipeTableCell/MGSwipeButton.m
+++ b/MGSwipeTableCell/MGSwipeButton.m
@@ -86,8 +86,7 @@
     return NO;
 }
 
--(void) centerIconOverText {
-	const CGFloat spacing = 3.0;
+-(void) centerIconOverTextWithSpacing: (CGFloat) spacing {
 	CGSize size = self.imageView.image.size;
 	self.titleEdgeInsets = UIEdgeInsetsMake(0.0,
 											-size.width,


### PR DESCRIPTION
The spacing was previously not customizable; now it is.