### PR TITLE
Fix to swipe background color changes

### DIFF
--- a/MGSwipeTableCell/MGSwipeTableCell.m
+++ b/MGSwipeTableCell/MGSwipeTableCell.m
@@ -1252,4 +1252,9 @@ static inline CGFloat mgEaseInOutBounce(CGFloat t, CGFloat b, CGFloat c) {
     return _panRecognizer.state == UIGestureRecognizerStateBegan || _panRecognizer.state == UIGestureRecognizerStateChanged;
 }
 
+-(void)setSwipeBackgroundColor:(UIColor *)swipeBackgroundColor {
+    _swipeBackgroundColor = swipeBackgroundColor;
+    _swipeOverlay.backgroundColor = swipeBackgroundColor;
+}
+
 @end


### PR DESCRIPTION
Before this fix, it a swipeBackgoundColor was set and then reset, it wouldn't update the swipe background color.

This adds support for the case in which a background is set and then needs to be changed without re-initializing the cell.