### PR TITLE
Fix crash upon rotation while buttons are displayed.

### DIFF
--- a/MGSwipeTableCell/MGSwipeTableCell.m
+++ b/MGSwipeTableCell/MGSwipeTableCell.m
@@ -774,9 +774,12 @@ static inline CGFloat mgEaseInOutBounce(CGFloat t, CGFloat b, CGFloat c) {
     CGFloat currentOffset = _swipeOffset;
     BOOL prevValue = _triggerStateChanges;
     _triggerStateChanges = NO;
-    self.swipeOffset = 0;
-    self.swipeOffset = currentOffset;
-    _triggerStateChanges = prevValue;
+    __block MGSwipeTableCell *blockSelf = self;
+    [self setSwipeOffset:0 animated:NO completion:^{
+        [blockSelf setSwipeOffset:currentOffset animated:NO completion:^{
+            _triggerStateChanges = prevValue;
+        }];
+    }];
 }
 
 -(void) refreshButtons: (BOOL) usingDelegate


### PR DESCRIPTION
While this does not happen in the demo applications, in my utilization of `MGSwipeTableCell` the following crash occurs when rotating with the buttons displayed (full stack at end of comment):

```
*** Terminating app due to uncaught exception 'NSGenericException', reason: '*** Collection <__NSArrayM: 0x7fe891571110> was mutated while being enumerated.'
```

In the original implementation of `refreshContentView`, `setSwipeOffset:` is fired by both `self.swipeOffset = 0;` & `self.swipeOffset = currentOffset;` which appears to cause some unhappiness.

This PR changes the two sets such that the custom setters are utilized and are executed serially - resolving my issue.

```
*** Terminating app due to uncaught exception 'NSGenericException', reason: '*** Collection <__NSArrayM: 0x7fe891571110> was mutated while being enumerated.'

    0   CoreFoundation                      0x0000000108ad1c65 __exceptionPreprocess + 165
    1   libobjc.A.dylib                     0x000000010af2dbb7 objc_exception_throw + 45
    2   CoreFoundation                      0x0000000108ad15c4 __NSFastEnumerationMutationHandler + 132
    3   UIKit                               0x00000001098edf5f -[UIViewController _updateLayoutForStatusBarAndInterfaceOrientation] + 1169
    4   UIKit                               0x00000001098ed897 -[UIViewController window:statusBarWillChangeFromHeight:toHeight:windowSizedViewController:] + 1894
    5   UIKit                               0x00000001098eda70 -[UIViewController window:statusBarWillChangeFromHeight:toHeight:] + 107
    6   UIKit                               0x0000000109811c29 -[UIWindow handleStatusBarChangeFromHeight:toHeight:] + 373
    7   UIKit                               0x0000000109814af0 +[UIWindow _noteStatusBarHeightChanged:oldHeight:forAutolayoutRootViewsOnly:] + 235
    8   UIKit                               0x00000001097bde12 __79-[UIApplication _setStatusBarHidden:animationParameters:changeApplicationFlag:]_block_invoke + 141
    9   UIKit                               0x00000001098343e2 +[UIView(UIViewAnimationWithBlocks) _setupAnimationWithDuration:delay:view:options:factory:animations:start:animationStateGenerator:completion:] + 473
    10  UIKit                               0x0000000109834678 +[UIView(UIViewAnimationWithBlocks) animateWithDuration:animations:completion:] + 59
    11  UIKit                               0x00000001097bdce0 -[UIApplication _setStatusBarHidden:animationParameters:changeApplicationFlag:] + 491
    12  UIKit                               0x00000001097be97a -[UIApplication setStatusBarOrientation:animationParameters:notifySpringBoardAndFence:] + 1455
    13  UIKit                               0x000000010980f235 __78-[UIWindow _rotateWindowToOrientation:updateStatusBar:duration:skipCallbacks:]_block_invoke1072 + 284
    14  UIKit                               0x0000000109c34100 __58-[_UIWindowRotationAnimationController animateTransition:]_block_invoke + 44
    15  UIKit                               0x00000001098343e2 +[UIView(UIViewAnimationWithBlocks) _setupAnimationWithDuration:delay:view:options:factory:animations:start:animationStateGenerator:completion:] + 473
    16  UIKit                               0x0000000109834637 +[UIView(UIViewAnimationWithBlocks) animateWithDuration:delay:options:animations:completion:] + 57
    17  UIKit                               0x0000000109c34090 -[_UIWindowRotationAnimationController animateTransition:] + 408
    18  UIKit                               0x000000010980ca09 -[UIWindow _rotateToBounds:withAnimator:transitionContext:] + 761
    19  UIKit                               0x000000010980ec77 -[UIWindow _rotateWindowToOrientation:updateStatusBar:duration:skipCallbacks:] + 1741
    20  UIKit                               0x000000010980f5ba -[UIWindow _setRotatableClient:toOrientation:applyTransformToWindow:updateStatusBar:duration:force:isRotating:] + 559
    21  UIKit                               0x000000010980e52e -[UIWindow _setRotatableClient:toOrientation:updateStatusBar:duration:force:isRotating:] + 116
    22  UIKit                               0x000000010980e4b4 -[UIWindow _setRotatableClient:toOrientation:updateStatusBar:duration:force:] + 36
    23  UIKit                               0x000000010980e361 -[UIWindow _setRotatableViewOrientation:updateStatusBar:duration:force:] + 122
    24  UIKit                               0x000000010980d3fe __57-[UIWindow _updateToInterfaceOrientation:duration:force:]_block_invoke + 98
    25  UIKit                               0x000000010980d34e -[UIWindow _updateToInterfaceOrientation:duration:force:] + 391
    26  UIKit                               0x000000010980d790 -[UIWindow _updateInterfaceOrientationFromDeviceOrientatilibc++abi.dylib: terminating with uncaught exception of type NSException
```
