### PR TITLE
Fix glitch on separators with vibrancy effect

### DIFF
--- a/MGSwipeTableCell/MGSwipeTableCell.m
+++ b/MGSwipeTableCell/MGSwipeTableCell.m
@@ -694,7 +694,7 @@ static inline CGFloat mgEaseInOutBounce(CGFloat t, CGFloat b, CGFloat c) {
 -(void) createSwipeViewIfNeeded
 {
     if (!_swipeOverlay) {
-        _swipeOverlay = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.bounds.size.width, self.bounds.size.height)];
+        _swipeOverlay = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.bounds.size.width, self.contentView.bounds.size.height)];
         [self fixRegionAndAccesoryViews];
         _swipeOverlay.hidden = YES;
         _swipeOverlay.backgroundColor = [self backgroundColorForSwipe];
@@ -739,7 +739,7 @@ static inline CGFloat mgEaseInOutBounce(CGFloat t, CGFloat b, CGFloat c) {
     if (_delegate && [_delegate respondsToSelector:@selector(swipeTableCellWillBeginSwiping:)]) {
         [_delegate swipeTableCellWillBeginSwiping:self];
     }
-    _swipeView.image = [self imageFromView:self];
+    _swipeView.image = [self imageFromView:self.contentView];
     _swipeOverlay.hidden = NO;
     if (_swipeContentView)
         [_swipeView addSubview:_swipeContentView];


### PR DESCRIPTION
Now takes screenshot of the cell's content view instead of the whole cell.
This implies that the cell's separator will not move with the cell being swiped anymore.
This is the expected behavior if we want to mimic swipe effect in native iOS Mail app.

Related to issue #193.