### PR TITLE
Do nothing with nil events caused by UIAutomation, fixes test automation

### DIFF
--- a/MGSwipeTableCell/MGSwipeTableCell.m
+++ b/MGSwipeTableCell/MGSwipeTableCell.m
@@ -24,6 +24,9 @@
 
 -(UIView *) hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
+    if (event == nil) {
+        return nil;
+    }
     if (!_currentCell) {
         [self removeFromSuperview];
         return nil;


### PR DESCRIPTION
Fix a bug where UIAutomation will cause nil events to be thrown in order to query the view. This can cause the MGSwipeTableCell to close an open slider thus making test automation of apps that use this hard. This fix looks for the nil event and returns so test automation can work like normal.