### PR TITLE
Attrubited title on buttons support

### DIFF
--- a/MGSwipeTableCell/MGSwipeButton.h
+++ b/MGSwipeTableCell/MGSwipeButton.h
@@ -8,7 +8,7 @@
 
 @class MGSwipeTableCell;
 
-/** 
+/**
  * This is a convenience class to create MGSwipeTableCell buttons
  * Using this class is optional because MGSwipeTableCell is button agnostic and can use any UIView for that purpose
  * Anyway, it's recommended that you use this class because is totally tested and easy to use ;)
@@ -25,7 +25,7 @@ typedef BOOL(^MGSwipeButtonCallback)(MGSwipeTableCell * sender);
 /** A width for the expanded buttons. Defaults to 0, which means sizeToFit will be called. */
 @property (nonatomic, assign) CGFloat buttonWidth;
 
-/** 
+/**
  * Convenience static constructors
  */
 +(instancetype) buttonWithTitle:(NSString *) title backgroundColor:(UIColor *) color;
@@ -39,7 +39,21 @@ typedef BOOL(^MGSwipeButtonCallback)(MGSwipeTableCell * sender);
 +(instancetype) buttonWithTitle:(NSString *) title icon:(UIImage*) icon backgroundColor:(UIColor *) color insets:(UIEdgeInsets) insets;
 +(instancetype) buttonWithTitle:(NSString *) title icon:(UIImage*) icon backgroundColor:(UIColor *) color callback:(MGSwipeButtonCallback) callback;
 +(instancetype) buttonWithTitle:(NSString *) title icon:(UIImage*) icon backgroundColor:(UIColor *) color padding:(NSInteger) padding callback:(MGSwipeButtonCallback) callback;
+
++(instancetype) buttonWithAttributedTitle:(NSAttributedString *) title backgroundColor:(UIColor *) color;
++(instancetype) buttonWithAttributedTitle:(NSAttributedString *) title backgroundColor:(UIColor *) color padding:(NSInteger) padding;
++(instancetype) buttonWithAttributedTitle:(NSAttributedString *) title backgroundColor:(UIColor *) color insets:(UIEdgeInsets) insets;
++(instancetype) buttonWithAttributedTitle:(NSAttributedString *) title backgroundColor:(UIColor *) color callback:(MGSwipeButtonCallback) callback;
++(instancetype) buttonWithAttributedTitle:(NSAttributedString *) title backgroundColor:(UIColor *) color padding:(NSInteger) padding callback:(MGSwipeButtonCallback) callback;
++(instancetype) buttonWithAttributedTitle:(NSAttributedString *) title backgroundColor:(UIColor *) color insets:(UIEdgeInsets) insets callback:(MGSwipeButtonCallback) callback;
++(instancetype) buttonWithAttributedTitle:(NSAttributedString *) title icon:(UIImage*) icon backgroundColor:(UIColor *) color;
++(instancetype) buttonWithAttributedTitle:(NSAttributedString *) title icon:(UIImage*) icon backgroundColor:(UIColor *) color padding:(NSInteger) padding;
++(instancetype) buttonWithAttributedTitle:(NSAttributedString *) title icon:(UIImage*) icon backgroundColor:(UIColor *) color insets:(UIEdgeInsets) insets;
++(instancetype) buttonWithAttributedTitle:(NSAttributedString *) title icon:(UIImage*) icon backgroundColor:(UIColor *) color callback:(MGSwipeButtonCallback) callback;
++(instancetype) buttonWithAttributedTitle:(NSAttributedString *) title icon:(UIImage*) icon backgroundColor:(UIColor *) color padding:(NSInteger) padding callback:(MGSwipeButtonCallback) callback;
+
 +(instancetype) buttonWithTitle:(NSString *) title icon:(UIImage*) icon backgroundColor:(UIColor *) color insets:(UIEdgeInsets) insets callback:(MGSwipeButtonCallback) callback;
++(instancetype) buttonWithAttributedTitle:(NSAttributedString *) attributedTitle icon:(UIImage*) icon backgroundColor:(UIColor *) color insets:(UIEdgeInsets) insets callback:(MGSwipeButtonCallback) callback;
 
 -(void) setPadding:(CGFloat) padding;
 -(void) setEdgeInsets:(UIEdgeInsets)insets;

--- a/MGSwipeTableCell/MGSwipeButton.m
+++ b/MGSwipeTableCell/MGSwipeButton.m
@@ -9,6 +9,7 @@
 
 @implementation MGSwipeButton
 
+// MARK: Convinience for plain titles
 +(instancetype) buttonWithTitle:(NSString *) title backgroundColor:(UIColor *) color
 {
     return [self buttonWithTitle:title icon:nil backgroundColor:color];
@@ -64,6 +65,63 @@
     return [self buttonWithTitle:title icon:icon backgroundColor:color insets:UIEdgeInsetsMake(0, padding, 0, padding) callback:callback];
 }
 
+// MARK: Convinience for attributed
++(instancetype) buttonWithAttributedTitle:(NSAttributedString *) title backgroundColor:(UIColor *) color
+{
+    return [self buttonWithAttributedTitle:title icon:nil backgroundColor:color];
+}
+
++(instancetype) buttonWithAttributedTitle:(NSAttributedString *) title backgroundColor:(UIColor *) color padding:(NSInteger) padding
+{
+    return [self buttonWithAttributedTitle:title icon:nil backgroundColor:color insets:UIEdgeInsetsMake(0, padding, 0, padding)];
+}
+
++(instancetype) buttonWithAttributedTitle:(NSAttributedString *) title backgroundColor:(UIColor *) color insets:(UIEdgeInsets) insets
+{
+    return [self buttonWithAttributedTitle:title icon:nil backgroundColor:color insets:insets];
+}
+
++(instancetype) buttonWithAttributedTitle:(NSAttributedString *) title backgroundColor:(UIColor *) color callback:(MGSwipeButtonCallback) callback
+{
+    return [self buttonWithAttributedTitle:title icon:nil backgroundColor:color callback:callback];
+}
+
++(instancetype) buttonWithAttributedTitle:(NSAttributedString *) title backgroundColor:(UIColor *) color padding:(NSInteger) padding callback:(MGSwipeButtonCallback) callback
+{
+    return [self buttonWithAttributedTitle:title icon:nil backgroundColor:color insets:UIEdgeInsetsMake(0, padding, 0, padding) callback:callback];
+}
+
++(instancetype) buttonWithAttributedTitle:(NSAttributedString *) title backgroundColor:(UIColor *) color insets:(UIEdgeInsets) insets callback:(MGSwipeButtonCallback) callback
+{
+    return [self buttonWithAttributedTitle:title icon:nil backgroundColor:color insets:insets callback:callback];
+}
+
++(instancetype) buttonWithAttributedTitle:(NSAttributedString *) title icon:(UIImage*) icon backgroundColor:(UIColor *) color
+{
+    return [self buttonWithAttributedTitle:title icon:icon backgroundColor:color callback:nil];
+}
+
++(instancetype) buttonWithAttributedTitle:(NSAttributedString *) title icon:(UIImage*) icon backgroundColor:(UIColor *) color padding:(NSInteger) padding
+{
+    return [self buttonWithAttributedTitle:title icon:icon backgroundColor:color insets:UIEdgeInsetsMake(0, padding, 0, padding) callback:nil];
+}
+
++(instancetype) buttonWithAttributedTitle:(NSAttributedString *) title icon:(UIImage*) icon backgroundColor:(UIColor *) color insets:(UIEdgeInsets) insets
+{
+    return [self buttonWithAttributedTitle:title icon:icon backgroundColor:color insets:insets callback:nil];
+}
+
++(instancetype) buttonWithAttributedTitle:(NSAttributedString *) title icon:(UIImage*) icon backgroundColor:(UIColor *) color callback:(MGSwipeButtonCallback) callback
+{
+    return [self buttonWithAttributedTitle:title icon:icon backgroundColor:color padding:10 callback:callback];
+}
+
++(instancetype) buttonWithAttributedTitle:(NSAttributedString *) title icon:(UIImage*) icon backgroundColor:(UIColor *) color padding:(NSInteger) padding callback:(MGSwipeButtonCallback) callback
+{
+    return [self buttonWithAttributedTitle:title icon:icon backgroundColor:color insets:UIEdgeInsetsMake(0, padding, 0, padding) callback:callback];
+}
+
+// MARK: Designated
 +(instancetype) buttonWithTitle:(NSString *) title icon:(UIImage*) icon backgroundColor:(UIColor *) color insets:(UIEdgeInsets) insets callback:(MGSwipeButtonCallback) callback
 {
     MGSwipeButton * button = [self buttonWithType:UIButtonTypeCustom];
@@ -72,11 +130,31 @@
     button.titleLabel.textAlignment = NSTextAlignmentCenter;
     [button setTitle:title forState:UIControlStateNormal];
     [button setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+    [button setTitleColor:[UIColor colorWithWhite:1.0 alpha:0.5] forState:UIControlStateHighlighted];
     [button setImage:icon forState:UIControlStateNormal];
+    [button setImage:icon forState:UIControlStateHighlighted];
     button.callback = callback;
     [button setEdgeInsets:insets];
     return button;
 }
+
++(instancetype) buttonWithAttributedTitle:(NSAttributedString *) attributedTitle icon:(UIImage*) icon backgroundColor:(UIColor *) color insets:(UIEdgeInsets) insets callback:(MGSwipeButtonCallback) callback
+{
+    MGSwipeButton * button = [self buttonWithType:UIButtonTypeCustom];
+    button.backgroundColor = color;
+    button.titleLabel.lineBreakMode = NSLineBreakByWordWrapping;
+    button.titleLabel.textAlignment = NSTextAlignmentCenter;
+    [button setAttributedTitle:attributedTitle forState:UIControlStateNormal];
+    [button setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+    [button setTitleColor:[UIColor colorWithWhite:1.0 alpha:0.5] forState:UIControlStateHighlighted];
+    [button setImage:icon forState:UIControlStateNormal];
+    [button setImage:icon forState:UIControlStateHighlighted];
+    button.callback = callback;
+    [button setEdgeInsets:insets];
+    return button;
+}
+
+// MARK:
 
 -(BOOL) callMGSwipeConvenienceCallback: (MGSwipeTableCell *) sender
 {
@@ -92,16 +170,16 @@
 }
 
 -(void) centerIconOverTextWithSpacing: (CGFloat) spacing {
-	CGSize size = self.imageView.image.size;
-	self.titleEdgeInsets = UIEdgeInsetsMake(0.0,
-											-size.width,
-											-(size.height + spacing),
-											0.0);
-	size = [self.titleLabel.text sizeWithAttributes:@{ NSFontAttributeName: self.titleLabel.font }];
-	self.imageEdgeInsets = UIEdgeInsetsMake(-(size.height + spacing),
-											0.0,
-											0.0,
-											-size.width);
+    CGSize size = self.imageView.image.size;
+    self.titleEdgeInsets = UIEdgeInsetsMake(0.0,
+                                            -size.width,
+                                            -(size.height + spacing),
+                                            0.0);
+    size = [self.titleLabel.text sizeWithAttributes:@{ NSFontAttributeName: self.titleLabel.font }];
+    self.imageEdgeInsets = UIEdgeInsetsMake(-(size.height + spacing),
+                                            0.0,
+                                            0.0,
+                                            -size.width);
 }
 
 -(void) setPadding:(CGFloat) padding

--- a/MGSwipeTableCell/MGSwipeTableCell.h
+++ b/MGSwipeTableCell/MGSwipeTableCell.h
@@ -60,10 +60,13 @@ typedef NS_ENUM(NSInteger, MGSwipeEasingFunction) {
  * Swipe animation settings
  **/
 @interface MGSwipeAnimation : NSObject
+
 /** Animation duration in seconds. Default value 0.3 */
 @property (nonatomic, assign) CGFloat duration;
+
 /** Animation easing function. Default value EaseOutBounce */
 @property (nonatomic, assign) MGSwipeEasingFunction easingFunction;
+
 /** Override this method to implement custom easing functions */
 -(CGFloat) value:(CGFloat) elapsed duration:(CGFloat) duration from:(CGFloat) from to:(CGFloat) to;
 
@@ -73,23 +76,30 @@ typedef NS_ENUM(NSInteger, MGSwipeEasingFunction) {
  * Swipe settings
  **/
 @interface MGSwipeSettings: NSObject
+
 /** Transition used while swiping buttons */
 @property (nonatomic, assign) MGSwipeTransition transition;
+
 /** Size proportional threshold to hide/keep the buttons when the user ends swiping. Default value 0.5 */
 @property (nonatomic, assign) CGFloat threshold;
-/** Optional offset to change the swipe buttons position. Relative to the cell border position. Default value: 0 
+
+/** Optional offset to change the swipe buttons position. Relative to the cell border position. Default value: 0
  ** For example it can be used to avoid cropped buttons when sectionIndexTitlesForTableView is used in the UITableView
  **/
 @property (nonatomic, assign) CGFloat offset;
+
 /** Top margin of the buttons relative to the contentView */
 @property (nonatomic, assign) CGFloat topMargin;
+
 /** Bottom margin of the buttons relative to the contentView */
 @property (nonatomic, assign) CGFloat bottomMargin;
 
 /** Animation settings when the swipe buttons are shown */
 @property (nonatomic, strong) MGSwipeAnimation * showAnimation;
+
 /** Animation settings when the swipe buttons are hided */
 @property (nonatomic, strong) MGSwipeAnimation * hideAnimation;
+
 /** Animation settings when the cell is stretched from the swipe buttons */
 @property (nonatomic, strong) MGSwipeAnimation * stretchAnimation;
 
@@ -115,16 +125,22 @@ typedef NS_ENUM(NSInteger, MGSwipeEasingFunction) {
  * Swipe button are not expandable by default
  **/
 @interface MGSwipeExpansionSettings: NSObject
+
 /** index of the expandable button (in the left or right buttons arrays) */
 @property (nonatomic, assign) NSInteger buttonIndex;
+
 /** if true the button fills the cell on trigger, else it bounces back to its initial position */
 @property (nonatomic, assign) BOOL fillOnTrigger;
+
 /** Size proportional threshold to trigger the expansion button. Default value 1.5 */
 @property (nonatomic, assign) CGFloat threshold;
+
 /** Optional expansion color. Expanded button's background color is used by default **/
 @property (nonatomic, strong) UIColor * expansionColor;
+
 /** Defines the layout of the expanded button **/
 @property (nonatomic, assign) MGSwipeExpansionLayout expansionLayout;
+
 /** Animation settings when the expansion is triggered **/
 @property (nonatomic, strong) MGSwipeAnimation * triggerAnimation;
 
@@ -132,6 +148,7 @@ typedef NS_ENUM(NSInteger, MGSwipeEasingFunction) {
  * The target animation is the change of a button from normal state to expanded state
  */
 @property (nonatomic, assign) CGFloat animationDuration;
+
 @end
 
 
@@ -226,25 +243,35 @@ typedef NS_ENUM(NSInteger, MGSwipeEasingFunction) {
 
 /** Readonly property to fetch the current swipe state */
 @property (nonatomic, readonly) MGSwipeState swipeState;
+
 /** Readonly property to check if the user swipe gesture is currently active */
 @property (nonatomic, readonly) BOOL isSwipeGestureActive;
 
 // default is NO. Controls whether multiple cells can be swiped simultaneously
 @property (nonatomic) BOOL allowsMultipleSwipe;
+
 // default is NO. Controls whether buttons with different width are allowed. Buttons are resized to have the same size by default.
 @property (nonatomic) BOOL allowsButtonsWithDifferentWidth;
+
 //default is YES. Controls whether swipe gesture is allowed when the touch starts into the swiped buttons
 @property (nonatomic) BOOL allowsSwipeWhenTappingButtons;
+
 //default is YES. Controls whether swipe gesture is allowed in opposite directions. NO value disables swiping in opposite direction once started in one direction
 @property (nonatomic) BOOL allowsOppositeSwipe;
+
 // default is NO.  Controls whether the cell selection/highlight status is preserved when expansion occurs
 @property (nonatomic) BOOL preservesSelectionStatus;
+
+/* default is NO. Controls whether the actions should take the width of the screen. When not enabled, the behaviour of calculation of cell widths stay the same. When enabled, every action button will be the same size. */
+@property (nonatomic) BOOL stretchToScreenWidth;
+
 /* default is NO. Controls whether dismissing a swiped cell when tapping outside of the cell generates a real touch event on the other cell.
  Default behaviour is the same as the Mail app on iOS. Enable it if you want to allow to start a new swipe while a cell is already in swiped in a single step.  */
 @property (nonatomic) BOOL touchOnDismissSwipe;
 
 /** Optional background color for swipe overlay. If not set, its inferred automatically from the cell contentView */
 @property (nonatomic, strong) UIColor * swipeBackgroundColor;
+
 /** Property to read or change the current swipe offset programmatically */
 @property (nonatomic, assign) CGFloat swipeOffset;
 

--- a/MGSwipeTableCell/MGSwipeTableCell.m
+++ b/MGSwipeTableCell/MGSwipeTableCell.m
@@ -68,17 +68,28 @@
 
 #pragma mark Layout
 
--(instancetype) initWithButtons:(NSArray*) buttonsArray direction:(MGSwipeDirection) direction differentWidth:(BOOL) differentWidth
+-(instancetype) initWithButtons:(NSArray*) buttonsArray
+                      direction:(MGSwipeDirection) direction
+                 differentWidth:(BOOL) differentWidth
+             stretchToScreenWidth:(BOOL) stretchToScreenWidth
 {
     CGFloat containerWidth = 0;
     CGSize maxSize = CGSizeZero;
-
+    
+    if (stretchToScreenWidth) {
+        maxSize.width = [UIScreen mainScreen].bounds.size.width / [@([buttonsArray count]) doubleValue];
+        containerWidth = [UIScreen mainScreen].bounds.size.width;
+    }
+    
     for (UIView * button in buttonsArray) {
-        containerWidth += button.bounds.size.width;
-        maxSize.width = MAX(maxSize.width, button.bounds.size.width);
+        if (!stretchToScreenWidth) {
+            containerWidth += button.bounds.size.width;
+            maxSize.width = MAX(maxSize.width, button.bounds.size.width);
+        }
         maxSize.height = MAX(maxSize.height, button.bounds.size.height);
     }
-    if (!differentWidth) {
+    
+    if (!stretchToScreenWidth && !differentWidth) {
         containerWidth = maxSize.width * buttonsArray.count;
     }
     
@@ -92,7 +103,9 @@
         for (UIView * button in _buttons) {
             if ([button isKindOfClass:[UIButton class]]) {
                 UIButton * btn = (UIButton*)button;
-                [btn removeTarget:nil action:@selector(mgButtonClicked:) forControlEvents:UIControlEventTouchUpInside]; //Remove all targets to avoid problems with reused buttons among many cells
+                
+                //Remove all targets to avoid problems with reused buttons among many cells
+                [btn removeTarget:nil action:@selector(mgButtonClicked:) forControlEvents:UIControlEventTouchUpInside];
                 [btn addTarget:self action:@selector(mgButtonClicked:) forControlEvents:UIControlEventTouchUpInside];
             }
             if (!differentWidth) {
@@ -709,14 +722,14 @@ static inline CGFloat mgEaseInOutBounce(CGFloat t, CGFloat b, CGFloat c) {
     
     [self fetchButtonsIfNeeded];
     if (!_leftView && _leftButtons.count > 0) {
-        _leftView = [[MGSwipeButtonsView alloc] initWithButtons:_leftButtons direction:MGSwipeDirectionLeftToRight differentWidth:_allowsButtonsWithDifferentWidth];
+        _leftView = [[MGSwipeButtonsView alloc] initWithButtons:_leftButtons direction:MGSwipeDirectionLeftToRight differentWidth:_allowsButtonsWithDifferentWidth stretchToScreenWidth:_stretchToScreenWidth];
         _leftView.cell = self;
         _leftView.frame = CGRectMake(-_leftView.bounds.size.width, _leftSwipeSettings.topMargin, _leftView.bounds.size.width, _swipeOverlay.bounds.size.height - _leftSwipeSettings.topMargin - _leftSwipeSettings.bottomMargin);
         _leftView.autoresizingMask = UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleHeight;
         [_swipeOverlay addSubview:_leftView];
     }
     if (!_rightView && _rightButtons.count > 0) {
-        _rightView = [[MGSwipeButtonsView alloc] initWithButtons:_rightButtons direction:MGSwipeDirectionRightToLeft differentWidth:_allowsButtonsWithDifferentWidth];
+        _rightView = [[MGSwipeButtonsView alloc] initWithButtons:_rightButtons direction:MGSwipeDirectionRightToLeft differentWidth:_allowsButtonsWithDifferentWidth stretchToScreenWidth:_stretchToScreenWidth];
         _rightView.cell = self;
         _rightView.frame = CGRectMake(_swipeOverlay.bounds.size.width, _rightSwipeSettings.topMargin, _rightView.bounds.size.width, _swipeOverlay.bounds.size.height - _rightSwipeSettings.topMargin - _rightSwipeSettings.bottomMargin);
         _rightView.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleHeight;


### PR DESCRIPTION
1. I added several methods to create MGSwipeButton with attributed string in its title in addition to the plain string. 
So, with 
`+(instancetype) buttonWithTitle:(NSString *) title backgroundColor:(UIColor *) color`
there will be 
`+(instancetype) buttonWithAttributedTitle:(NSAttributedString *) title backgroundColor:(UIColor *) color`
that sets attributed text on button's titleLabel. And so on for the rest convenience constructors.

2. Added the flag `stretchToScreenWidth` so action buttons will take whole width of the screen, and divide it in even parts. 
Default value if `NO`, as it was.