### PR TITLE
Fix glitch when dragging before animation completes

### DIFF
--- a/MGSwipeTableCell/MGSwipeTableCell.m
+++ b/MGSwipeTableCell/MGSwipeTableCell.m
@@ -1114,14 +1114,20 @@ static inline CGFloat mgEaseInOutBounce(CGFloat t, CGFloat b, CGFloat c) {
     //call animation completion and invalidate timer
     if (completed){
         [timer invalidate];
-        _displayLink = nil;
-        if (_animationCompletion) {
-            void (^callbackCopy)(BOOL finished) = _animationCompletion; //copy to avoid duplicated callbacks
-            _animationCompletion = nil;
-            callbackCopy(YES);
-        }
+        [self invalidateDisplayLink];
     }
 }
+
+-(void)invalidateDisplayLink {
+    [_displayLink invalidate];
+    _displayLink = nil;
+    if (_animationCompletion) {
+        void (^callbackCopy)(BOOL finished) = _animationCompletion; //copy to avoid duplicated callbacks
+        _animationCompletion = nil;
+        callbackCopy(YES);
+    }
+}
+
 -(void) setSwipeOffset:(CGFloat)offset animated: (BOOL) animated completion:(void(^)(BOOL finished)) completion
 {
     MGSwipeAnimation * animation = animated ? [[MGSwipeAnimation alloc] init] : nil;
@@ -1207,6 +1213,8 @@ static inline CGFloat mgEaseInOutBounce(CGFloat t, CGFloat b, CGFloat c) {
     CGPoint current = [gesture translationInView:self];
     
     if (gesture.state == UIGestureRecognizerStateBegan) {
+        [self invalidateDisplayLink];
+
         if (!_preservesSelectionStatus)
             self.highlighted = NO;
         [self createSwipeViewIfNeeded];


### PR DESCRIPTION
When a drag occurs before the animation completes, the animation would glitch and the offset would alternate between the drag position and the offset based on the animation's progress.

Fixed it by invalidating the CADisplayLink when a drag begins.

<img width="540" alt="screen shot 2016-10-06 at 9 26 05 pm" src="https://cloud.githubusercontent.com/assets/4634735/19176196/845824fc-8c0b-11e6-8265-f6953d3902c9.png">
