### PR TITLE
Fix static analyser warnings

### DIFF
--- a/MGSwipeTableCell/MGSwipeTableCell.h
+++ b/MGSwipeTableCell/MGSwipeTableCell.h
@@ -258,7 +258,7 @@ typedef NS_ENUM(NSInteger, MGSwipeEasingFunction) {
 -(void) showSwipe: (MGSwipeDirection) direction animated: (BOOL) animated;
 -(void) showSwipe: (MGSwipeDirection) direction animated: (BOOL) animated completion:(nullable void(^)(BOOL finished)) completion;
 -(void) setSwipeOffset:(CGFloat)offset animated: (BOOL) animated completion:(nullable void(^)(BOOL finished)) completion;
--(void) setSwipeOffset:(CGFloat)offset animation: (nonnull MGSwipeAnimation *) animation completion:(nullable void(^)(BOOL finished)) completion;
+-(void) setSwipeOffset:(CGFloat)offset animation: (nullable MGSwipeAnimation *) animation completion:(nullable void(^)(BOOL finished)) completion;
 -(void) expandSwipe: (MGSwipeDirection) direction animated: (BOOL) animated;
 
 /** Refresh method to be used when you want to update the cell contents while the user is swiping */


### PR DESCRIPTION
There is a nil used in the method realisation for the second argument, but method signature declared as nonnull for it.
