### PR TITLE
Set and restore the flipped geometry flag

### DIFF
--- a/MGSwipeTableCell/MGSwipeTableCell.m
+++ b/MGSwipeTableCell/MGSwipeTableCell.m
@@ -1026,13 +1026,21 @@ static inline CGFloat mgEaseInOutBounce(CGFloat t, CGFloat b, CGFloat c) {
 #pragma mark Some utility methods
 
 - (UIImage *)imageFromView:(UIView *)view cropSize:(CGSize)cropSize{
+    
     BOOL originalGeometry = view.layer.geometryFlipped;
+    BOOL superviewOriginalGeometry = view.superview.layer.geometryFlipped;
+    
     view.layer.geometryFlipped = NO;
+    view.superview.layer.geometryFlipped = NO;
+    
     UIGraphicsBeginImageContextWithOptions(cropSize, NO, 0);
     [view drawViewHierarchyInRect:view.bounds afterScreenUpdates:YES];
     UIImage * image = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
+
     view.layer.geometryFlipped = originalGeometry;
+    view.superview.layer.geometryFlipped = superviewOriginalGeometry;
+    
     return image;
 }
 


### PR DESCRIPTION
On a table with flipped geometry (where row zero is the bottom of the table) each of the cells usually also have flipped geometry to ensure the UI renders correctly. The `imageFromView` wasn't taking this into account so I've cached the `geometryFlipped` value on the cell so that we can render the image with the natural geometry.