### PR TITLE
Fix iOS 13 crash when reselecting a cell that's being removed (Issue #334)

### DIFF
--- a/MGSwipeTableCell/MGSwipeTableCell.m
+++ b/MGSwipeTableCell/MGSwipeTableCell.m
@@ -659,7 +659,7 @@ static inline CGFloat mgEaseInOutBounce(CGFloat t, CGFloat b, CGFloat c) {
 
 -(void) dealloc
 {
-    [self hideSwipeOverlayIfNeeded];
+    [self hideSwipeOverlayIfNeededIncludingReselect:false];
 }
 
 -(void) initViews: (BOOL) cleanButtons
@@ -904,7 +904,7 @@ static inline CGFloat mgEaseInOutBounce(CGFloat t, CGFloat b, CGFloat c) {
     [self addGestureRecognizer:_tapRecognizer];
 }
 
--(void) hideSwipeOverlayIfNeeded
+-(void) hideSwipeOverlayIfNeededIncludingReselect: (BOOL) reselectCellIfNeeded
 {
     if (!_overlayEnabled) {
         return;
@@ -921,12 +921,14 @@ static inline CGFloat mgEaseInOutBounce(CGFloat t, CGFloat b, CGFloat c) {
         [_tableInputOverlay removeFromSuperview];
         _tableInputOverlay = nil;
     }
-    
-    self.selectionStyle = _previusSelectionStyle;
-    NSArray * selectedRows = self.parentTable.indexPathsForSelectedRows;
-    if ([selectedRows containsObject:[self.parentTable indexPathForCell:self]]) {
-        self.selected = NO; //Hack: in some iOS versions setting the selected property to YES own isn't enough to force the cell to redraw the chosen selectionStyle
-        self.selected = YES;
+
+    if (reselectCellIfNeeded) {
+        self.selectionStyle = _previusSelectionStyle;
+        NSArray * selectedRows = self.parentTable.indexPathsForSelectedRows;
+        if ([selectedRows containsObject:[self.parentTable indexPathForCell:self]]) {
+            self.selected = NO; //Hack: in some iOS versions setting the selected property to YES own isn't enough to force the cell to redraw the chosen selectionStyle
+            self.selected = YES;
+        }
     }
     [self setAccesoryViewsHidden:NO];
     
@@ -973,7 +975,7 @@ static inline CGFloat mgEaseInOutBounce(CGFloat t, CGFloat b, CGFloat c) {
 -(void) willMoveToSuperview:(UIView *)newSuperview;
 {
     if (newSuperview == nil) { //remove the table overlay when a cell is removed from the table
-        [self hideSwipeOverlayIfNeeded];
+        [self hideSwipeOverlayIfNeededIncludingReselect:false];
     }
 }
 
@@ -1126,7 +1128,7 @@ static inline CGFloat mgEaseInOutBounce(CGFloat t, CGFloat b, CGFloat c) {
             [_leftView endExpansionAnimated:NO];
         if (_rightView)
             [_rightView endExpansionAnimated:NO];
-        [self hideSwipeOverlayIfNeeded];
+        [self hideSwipeOverlayIfNeededIncludingReselect:true];
         _targetOffset = 0;
         [self updateState:MGSwipeStateNone];
         return;


### PR DESCRIPTION
Issue #334 
Fixed the crashes I was able to reproduce on iOS 13. The crash happened on `self.selectionStyle = _previusSelectionStyle;` so I skipped this code for `dealloc` and `willMoveToSuperview:`.

I tested MGSwipeDemo to see if selected cells were re-selected when scrolled off screen and back on, and when swipes were cancelled. If there are other test cases to do, please let me know.