### PR TITLE
Resolves #363 Visual glitch/flash on refreshContentView() while cell is swiped open

### DIFF
--- a/MGSwipeTableCell/MGSwipeTableCell.m
+++ b/MGSwipeTableCell/MGSwipeTableCell.m
@@ -1029,10 +1029,10 @@ static inline CGFloat mgEaseInOutBounce(CGFloat t, CGFloat b, CGFloat c) {
 #pragma mark Some utility methods
 
 - (UIImage *)imageFromView:(UIView *)view cropSize:(CGSize)cropSize{
-    UIGraphicsBeginImageContextWithOptions(cropSize, NO, 0);
-    [view drawViewHierarchyInRect:view.bounds afterScreenUpdates:YES];
-    UIImage * image = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:cropSize];
+    UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
+        [view.layer renderInContext:[rendererContext CGContext]];
+    }];
     return image;
 }
 


### PR DESCRIPTION
Specifically, when `refreshContentView()` is called, a new UIImage snapshot of the cell's content view is created using the older `- (BOOL)drawViewHierarchyInRect:(CGRect)rect afterScreenUpdates:(BOOL)afterUpdates` with `UIGraphicsBeginImageContextWithOptions`.  In order to cause the new content to be rendered, `afterUpdates` must be `YES`, which causes the user's screen to redraw in order to make the latest content available.

Changed `- (UIImage *)imageFromView:(UIView *)view cropSize:(CGSize)cropSize` to use `UIGraphicsRenderer` and `- (void)renderInContext:(CGContextRef)ctx` instead, eliminating the need to draw a view update to the screen.

Resolves https://github.com/MortimerGoro/MGSwipeTableCell/issues/363